### PR TITLE
Replace Azure/OpenAI references for AWS Bedrock service references

### DIFF
--- a/3-README-prompt-roles.md
+++ b/3-README-prompt-roles.md
@@ -10,7 +10,7 @@ The `PromptTemplateController` accepts HTTP GET requests at `http://localhost:80
 * `name`, The name of the AI assistant.  The default value is `Bob`
 * `voice`, The style of voice that the AI assistant will use to reply.  The default value is `pirate`
 
-The response to the request is from the Azure OpenAI Service.
+The response to the request is from the AWS Bedrock Service.
 
 ## Roles
 

--- a/4-README-output-parser.md
+++ b/4-README-output-parser.md
@@ -21,14 +21,14 @@ The `format` variable is obtained from the `OutputParser`
 
 ## BeanOutputParser
 
-The `BeanOutputParser` generates an OpenAI JSON compliant schema for a JavaBean and provides instructions to use that schema when replying to a request.
+The `BeanOutputParser` generates an Bedrock JSON compliant schema for a JavaBean and provides instructions to use that schema when replying to a request.
 
 ```java
 var outputParser = new BeanOutputParser<>(ActorsFilms.class);
 String format = outputParser.getFormat();
 ```
 
-The response from the Azure OpenAI Service is then parsed into the class `ActorsFilms`
+The response from the AWS Bedrock Service is then parsed into the class `ActorsFilms`
 
 ```java
 ActorsFilms actorsFilms = outputParser.parse(generation.getOutput().getContent());

--- a/5-README-stuff-prompt.md
+++ b/5-README-stuff-prompt.md
@@ -9,7 +9,7 @@ By incorporating data into the prompt, you enable AI models to generate more acc
 For this example, we'll explore a query about Curling in the 2022 Olympics. The dataset used to train the AI model only goes up until September 2021. 
 Therefore, without furnishing additional data in the prompt, the model won't be capable of answering the question.
 
-The technique simply includes a document within the prompt sent to Azure OPenAI that provides information about Curling in the 2022 Olympics.
+The technique simply includes a document within the prompt sent to AWS Bedrock service that provides information about Curling in the 2022 Olympics.
 
 ## Code Location and walkthrough
 
@@ -27,7 +27,7 @@ The default value is
 Which athletes won the gold medal in curling at the 2022 Winter Olympics?
 ```
 
-The response to the request is from the Azure OpenAI Service.
+The response to the request is from the AWS Bedrock Service.
 
 ## Building and running
 
@@ -59,7 +59,7 @@ This will result in a response like this:
 
 ## Stuffing the prompt
 
-Now we will provide relevant information for Azure OpenAI to refer to reference.
+Now we will provide relevant information for AWS Bedrock to refer to reference.
 
 We'll use Wikipedia article on Curling at the 2022 Winter Olympics.[Curling a the 2022 Winter Olympics ](https://en.wikipedia.org/wiki/Curling_at_the_2022_Winter_Olympics).
 

--- a/6-README-retrieval-augmented-generation.md
+++ b/6-README-retrieval-augmented-generation.md
@@ -28,7 +28,7 @@ The steps of processing are
         List<Document> documents = jsonReader.get();
 ```
 
-Create embeddings for the documents.  This calls the Azure OpenAI embedding endpoint.
+Create embeddings for the documents.  This calls the AWS Bedrock embedding endpoint.
 
 ```java
         VectorStore vectorStore = new SimpleVectorStore(embeddingClient);
@@ -56,7 +56,7 @@ The `Prompt` is created from a System message and a User message.  The System me
         ChatResponse chatResponse = chatClient.call(prompt);
 ```
 
-The response to the request is from the Azure OpenAI Service.
+The response to the request is from the AWS Bedrock service.
 
 ## Building and running
 


### PR DESCRIPTION
## Purpose
Correct inaccurate references to OpenAI/Azure OpenAI to AWS Bedrock
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [(https://github.com/ryanconley1/spring-ai-bedrock-anthropic-titan-workshop)]
cd [[spring-ai-bedrock-anthropic-titan-workshop](https://github.com/ryanconley1/spring-ai-bedrock-anthropic-titan-workshop)]
git checkout [main]
```

* Test the code
Review README's 1-6 to confirm AWS Bedrock is correctly referenced in guides.
```
```

## What to Check
Guides should reference AWS Bedrock instead of Azure OpenAI or Open AI services
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->